### PR TITLE
Change method return type of deleting user in Admin controller/service

### DIFF
--- a/src/main/java/com/kaloyan/notetakingapp/controller/AdminController.java
+++ b/src/main/java/com/kaloyan/notetakingapp/controller/AdminController.java
@@ -25,7 +25,7 @@ public class AdminController {
 
     @PreAuthorize("@adminServiceImpl.isNotAdmin(#userId)")
     @DeleteMapping("/users/{id}")
-    public Flux<Void> deleteUser(@PathVariable("id") UUID userId) {
+    public Mono<Void> deleteUser(@PathVariable("id") UUID userId) {
         return adminService.deleteUser(userId);
     }
 

--- a/src/main/java/com/kaloyan/notetakingapp/service/AdminService.java
+++ b/src/main/java/com/kaloyan/notetakingapp/service/AdminService.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public interface AdminService {
 
-    Flux<Void> deleteUser(UUID userId);
+    Mono<Void> deleteUser(UUID userId);
 
     Mono<Void> deleteNote(UUID noteId);
 


### PR DESCRIPTION
Change method return type from Flux<Void> to Mono<Void> because of the new implementation in AdminServiceImpl using Mono.then instead of Flux.merge