### PR TITLE
Fix registration filter, add comments and javadoc

### DIFF
--- a/src/main/java/com/kaloyan/notetakingapp/config/R2dbcConfig.java
+++ b/src/main/java/com/kaloyan/notetakingapp/config/R2dbcConfig.java
@@ -16,6 +16,7 @@ public class R2dbcConfig {
         return new R2dbcEntityTemplate(connectionFactory);
     }
 
+    //Database schema is kept in resources/schema.sql
     @Bean
     ConnectionFactoryInitializer initializer(ConnectionFactory connectionFactory) {
 

--- a/src/main/java/com/kaloyan/notetakingapp/config/SecurityConfig.java
+++ b/src/main/java/com/kaloyan/notetakingapp/config/SecurityConfig.java
@@ -3,12 +3,16 @@ package com.kaloyan.notetakingapp.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.authorization.AuthorizationContext;
+import reactor.core.publisher.Mono;
 
 @EnableWebFluxSecurity
 @Configuration
@@ -23,9 +27,14 @@ public class SecurityConfig {
     public SecurityWebFilterChain securityFilterChain(ServerHttpSecurity http) {
         http.authorizeExchange(authorizeExchangeSpec -> authorizeExchangeSpec
                 .pathMatchers(HttpMethod.GET, "/**").permitAll()
-                .pathMatchers(HttpMethod.POST, "/users").permitAll()
+                .pathMatchers(HttpMethod.POST, "/users").access(this::isNotAuthenticated)
                 .pathMatchers("/admin").hasRole("ROLE_ADMIN").anyExchange().authenticated()).httpBasic(Customizer.withDefaults());
         http.csrf(ServerHttpSecurity.CsrfSpec::disable);
         return http.build();
+    }
+
+    private Mono<AuthorizationDecision> isNotAuthenticated(Mono<Authentication> authenticationMono, AuthorizationContext context) {
+        return authenticationMono
+                .map(authentication -> new AuthorizationDecision(!authentication.isAuthenticated()));
     }
 }

--- a/src/main/java/com/kaloyan/notetakingapp/config/SecurityConfig.java
+++ b/src/main/java/com/kaloyan/notetakingapp/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
 
     private Mono<AuthorizationDecision> isNotAuthenticated(Mono<Authentication> authenticationMono, AuthorizationContext context) {
         return authenticationMono
-                .map(authentication -> new AuthorizationDecision(!authentication.isAuthenticated()));
+                .map(authentication -> new AuthorizationDecision(!authentication.isAuthenticated()))
+                .defaultIfEmpty(new AuthorizationDecision(true));
     }
 }

--- a/src/main/java/com/kaloyan/notetakingapp/controller/UserController.java
+++ b/src/main/java/com/kaloyan/notetakingapp/controller/UserController.java
@@ -43,7 +43,7 @@ public class UserController {
     }
 
     @DeleteMapping("/{id}")
-    public Flux<Void> deleteUser(@PathVariable("id") UUID userId) {
+    public Mono<Void> deleteUser(@PathVariable("id") UUID userId) {
         return userService.deleteById(userId);
     }
 }

--- a/src/main/java/com/kaloyan/notetakingapp/service/AdminService.java
+++ b/src/main/java/com/kaloyan/notetakingapp/service/AdminService.java
@@ -17,6 +17,7 @@ public interface AdminService {
     /**
      * SPeL throws exception when trying to get the opposite result of a Mono<Boolean>
      * which is why the method in AdminService is "isNotAdmin" instead of "isAdmin"
+     * so that it can be used with @PreAuthorize annotation
      * */
     Mono<Boolean> isNotAdmin(UUID userId);
 }

--- a/src/main/java/com/kaloyan/notetakingapp/service/AdminService.java
+++ b/src/main/java/com/kaloyan/notetakingapp/service/AdminService.java
@@ -6,18 +6,44 @@ import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
+/**
+ * Service interface for administrative operations.
+ * Provides functionality to manage users, notes, and user roles.
+ */
 public interface AdminService {
 
+    /**
+     * Deletes a user with the specified UUID.
+     *
+     * @param userId the UUID of the user to be deleted
+     * @return a {@link Mono} that completes when the user is deleted
+     */
     Mono<Void> deleteUser(UUID userId);
 
+    /**
+     * Deletes a note with the specified UUID.
+     *
+     * @param noteId the UUID of the note to be deleted
+     * @return a {@link Mono} that completes when the note is deleted
+     */
     Mono<Void> deleteNote(UUID noteId);
 
+    /**
+     * Grants admin privileges to a user with the specified UUID.
+     *
+     * @param userId the UUID of the user to be promoted to admin
+     * @return a {@link Mono} containing the updated {@link UserDTO} of the user
+     */
     Mono<UserDTO> makeUserAdmin(UUID userId);
 
     /**
-     * SPeL throws exception when trying to get the opposite result of a Mono<Boolean>
-     * which is why the method in AdminService is "isNotAdmin" instead of "isAdmin"
-     * so that it can be used with @PreAuthorize annotation
-     * */
+     * Determines if a user is not an admin.
+     * <p>
+     * This method is designed to be used with Spring Security's {@code @PreAuthorize}
+     * annotation due to limitations with SpEL when negating a {@link Mono<Boolean>}.
+     *
+     * @param userId the UUID of the user
+     * @return a {@link Mono} emitting {@code true} if the user is not an admin, {@code false} otherwise
+     */
     Mono<Boolean> isNotAdmin(UUID userId);
 }

--- a/src/main/java/com/kaloyan/notetakingapp/service/NoteService.java
+++ b/src/main/java/com/kaloyan/notetakingapp/service/NoteService.java
@@ -7,15 +7,50 @@ import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
+/**
+ * Service interface for managing notes.
+ * Provides operations to find, save, edit, and delete notes.
+ */
 public interface NoteService {
 
+    /**
+     * Retrieves a note by its UUID.
+     *
+     * @param uuid the UUID of the note to be retrieved
+     * @return a {@link Mono} containing the {@link NoteDTO} with the specified UUID, or empty if not found
+     */
     Mono<NoteDTO> findById(UUID uuid);
 
+    /**
+     * Retrieves all notes with pagination support.
+     *
+     * @param pageable the {@link Pageable} object specifying pagination information
+     * @return a {@link Flux} containing {@link NoteDTO}s for the requested page
+     */
     Flux<NoteDTO> findAll(Pageable pageable);
 
+    /**
+     * Saves a new note or updates an existing note.
+     *
+     * @param noteDTO the {@link NoteDTO} to be saved or updated
+     * @return a {@link Mono} containing the saved {@link NoteDTO}
+     */
     Mono<NoteDTO> save(NoteDTO noteDTO);
 
+    /**
+     * Edits an existing note identified by its UUID.
+     *
+     * @param uuid the UUID of the note to be edited
+     * @param noteDTO the {@link NoteDTO} containing updated information for the note
+     * @return a {@link Mono} containing the updated {@link NoteDTO}
+     */
     Mono<NoteDTO> edit(UUID uuid, NoteDTO noteDTO);
 
+    /**
+     * Deletes a note by its UUID.
+     *
+     * @param uuid the UUID of the note to be deleted
+     * @return a {@link Mono} that completes when the note is deleted
+     */
     Mono<Void> deleteById(UUID uuid);
 }

--- a/src/main/java/com/kaloyan/notetakingapp/service/NoteServiceImpl.java
+++ b/src/main/java/com/kaloyan/notetakingapp/service/NoteServiceImpl.java
@@ -25,6 +25,7 @@ public class NoteServiceImpl implements NoteService {
     @Autowired
     NoteRepository noteRepository;
 
+    //Reactive repositories do not support joins so this method is used to populate the user field of the note objects
     private Mono<Note> noteWithUser(UUID noteId) {
         return noteRepository.findById(noteId).flatMap(note -> userRepository.findById(note.getUserId()).map(user -> {
             note.setUser(user);

--- a/src/main/java/com/kaloyan/notetakingapp/service/NoteServiceImpl.java
+++ b/src/main/java/com/kaloyan/notetakingapp/service/NoteServiceImpl.java
@@ -38,6 +38,7 @@ public class NoteServiceImpl implements NoteService {
         return noteWithUser(uuid).map(NoteDTO::new);
     }
 
+    //Reactive repositories do not support pagination with Pageable so it is done by skipping pageNumber*pageSize entries and then taking pageSize entries
     @Override
     public Flux<NoteDTO> findAll(Pageable pageable) {
         return noteRepository.findAll().flatMap(note -> noteWithUser(note.getId())).map(NoteDTO::new)

--- a/src/main/java/com/kaloyan/notetakingapp/service/UserService.java
+++ b/src/main/java/com/kaloyan/notetakingapp/service/UserService.java
@@ -8,13 +8,45 @@ import reactor.core.publisher.Mono;
 import java.util.UUID;
 
 public interface UserService {
+
+    /**
+     * Retrieves a user by their UUID.
+     *
+     * @param uuid the UUID of the user to be retrieved
+     * @return a {@link Mono} containing the {@link UserDTO} with the specified UUID, or empty if not found
+     */
     Mono<UserDTO> findById(UUID uuid);
 
+    /**
+     * Retrieves all users with pagination support.
+     *
+     * @param pageable the {@link Pageable} object specifying pagination information
+     * @return a {@link Flux} containing {@link UserDTO}s for the requested page
+     */
     Flux<UserDTO> findAll(Pageable pageable);
 
+    /**
+     * Saves a new user or updates an existing user.
+     *
+     * @param userDTO the {@link UserDTO} to be saved or updated
+     * @return a {@link Mono} containing the saved or updated {@link UserDTO}
+     */
     Mono<UserDTO> save(UserDTO userDTO);
 
+    /**
+     * Updates the username of an existing user identified by their UUID.
+     *
+     * @param uuid the UUID of the user whose username is to be updated
+     * @param username the new username to be set
+     * @return a {@link Mono} containing the updated {@link UserDTO} with the new username
+     */
     Mono<UserDTO> patchUsername(UUID uuid, String username);
 
-    Flux<Void> deleteById(UUID uuid);
+    /**
+     * Deletes a user by their UUID.
+     *
+     * @param uuid the UUID of the user to be deleted
+     * @return a {@link Mono} that completes when the user is deleted
+     */
+    Mono<Void> deleteById(UUID uuid);
 }

--- a/src/main/java/com/kaloyan/notetakingapp/service/UserServiceImpl.java
+++ b/src/main/java/com/kaloyan/notetakingapp/service/UserServiceImpl.java
@@ -43,6 +43,7 @@ public class UserServiceImpl implements UserService {
         return userRepository.findById(uuid).flatMap(this::userWithNotes);
     }
 
+    //Reactive repositories do not support pagination with Pageable so it is done by skipping pageNumber*pageSize entries and then taking pageSize entries
     @Override
     public Flux<UserDTO> findAll(Pageable pageable) {
         return userRepository.findAll().flatMap(this::userWithNotes)
@@ -69,12 +70,12 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public Flux<Void> deleteById(UUID uuid) {
-        return SecurityUtils.authenticatedUsername().flatMapMany(username -> userRepository.findById(uuid).flatMapMany(u -> {
+    public Mono<Void> deleteById(UUID uuid) {
+        return SecurityUtils.authenticatedUsername().flatMap(username -> userRepository.findById(uuid).flatMap(u -> {
                     if (!u.getUsername().equals(username)) {
                         throw new DifferentUserException("Users are forbidden from deleting other Users!");
                     }
-                    return Flux.merge(noteRepository.deleteByUserId(uuid), userRepository.deleteById(uuid));
+                    return Mono.when(noteRepository.deleteByUserId(uuid), userRepository.deleteById(uuid));
                 }
         ));
     }

--- a/src/main/java/com/kaloyan/notetakingapp/service/UserServiceImpl.java
+++ b/src/main/java/com/kaloyan/notetakingapp/service/UserServiceImpl.java
@@ -30,6 +30,7 @@ public class UserServiceImpl implements UserService {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    //Reactive repositories do not support joins so this method is used to populate the notes field of the user objects
     private Mono<UserDTO> userWithNotes(User user) {
         return noteRepository.findByUserId(user.getId()).collectList().flatMap(notes -> {
             user.setNotes(notes);

--- a/src/test/java/com/kaloyan/notetakingapp/controller/UserControllerUnitTests.java
+++ b/src/test/java/com/kaloyan/notetakingapp/controller/UserControllerUnitTests.java
@@ -69,7 +69,7 @@ public class UserControllerUnitTests {
     @Test
     @WithUserDetails
     public void deletingUserReturns200(){
-        Mockito.when(userService.deleteById(any())).thenReturn(Flux.empty());
+        Mockito.when(userService.deleteById(any())).thenReturn(Mono.empty());
         webTestClient.delete().uri("/users/" + userId).exchange().expectStatus().isOk();
     }
 

--- a/src/test/java/com/kaloyan/notetakingapp/service/UserServiceUnitTests.java
+++ b/src/test/java/com/kaloyan/notetakingapp/service/UserServiceUnitTests.java
@@ -91,7 +91,7 @@ public class UserServiceUnitTests {
             utilities.when(SecurityUtils::authenticatedUsername).thenReturn(Mono.just("differentUsername"));
             Mockito.when(userRepository.findById(userId)).thenReturn(Mono.just(user));
 
-            Flux<Void> returned = userService.deleteById(user.getId());
+            Mono<Void> returned = userService.deleteById(user.getId());
             StepVerifier.create(returned).verifyErrorMatches(throwable -> throwable instanceof DifferentUserException);
         }
     }


### PR DESCRIPTION
Add a check that denies already registered users to register again
Add javadoc to service interfaces, add comments to service implementations
Change deleteById in user service to return Mono<Void> to be consistent with the other parts of the API